### PR TITLE
fix: fix typo

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2397,7 +2397,7 @@ export interface FontMgr extends EmbindObject<FontMgr> {
      * Create a typeface for the specified bytes and return it.
      * @param fontData
      */
-  makeTypefaceFromData(fontData: ArrayBuffer): Typeface;
+  MakeTypefaceFromData(fontData: ArrayBuffer): Typeface;
 }
 
 /**


### PR DESCRIPTION
```TypeScript
import CanvasKit from "https://deno.land/x/canvas/mod.ts";

console.log(CanvasKit.FontMgr.RefDefault().makeTypefaceFromData);
// undefined

console.log((CanvasKit.FontMgr.RefDefault() as any).MakeTypefaceFromData);
// [Function]
```